### PR TITLE
Add support for non-git repository through manual file selection prompt

### DIFF
--- a/commands/security/analyze.toml
+++ b/commands/security/analyze.toml
@@ -26,8 +26,8 @@ You will now begin executing the plan. The following are your precise instructio
 
 1b. **To define the audit scope in a non-git folder** 
     *   Let the user know that you were unable to generate an automatic changelist with git, so you **MUST** prompt the user for files to security scan. 
-    *   Match the users response to files in the workspace and build a list of files to change.
-    *   This is your only method for determining the changed files. Do not use any other commands for this purpose.
+    *   Match the users response to files in the workspace and build a list of files to analyze.
+    *   This is your only method for determining the files to analyze. Do not use any other commands for this purpose.
     *   Once you have a list of files to analyze you will mark this task as complete.
 
 2.  **Immediately after defining the scope, you must refine your plan:**


### PR DESCRIPTION
Add branching behavior for non git repositories, allows user to describe/select the files they would like to add. Please let me know if there's a better way to introduce this branching to the prompt, or if we should craft the prompt in a way such that we don't have these explicit branches in the first place.

**Non-git**
<img width="1084" height="758" alt="Screenshot 2025-09-18 at 1 16 08 PM" src="https://github.com/user-attachments/assets/22945db5-5d0e-469d-8f9c-7b78faa54270" />

**Git**
<img width="1282" height="607" alt="Screenshot 2025-09-18 at 1 18 52 PM" src="https://github.com/user-attachments/assets/dffcc1cf-b724-4400-8f56-5449e554faf2" />
