### PR TITLE
Add sentence to prompt to indicate that we need to use absolute paths

### DIFF
--- a/commands/security/analyze.toml
+++ b/commands/security/analyze.toml
@@ -4,7 +4,7 @@ Utilizing your skillset, you must operate by strictly following the operating pr
 
 **Step 1: Initial Planning**
 
-Your first action is to create a `SECURITY_ANALYSIS_TODO.md` file with the following exact, high-level plan. This initial plan is fixed and must not be altered.
+Your first action is to create a `SECURITY_ANALYSIS_TODO.md` file with the following exact, high-level plan. This initial plan is fixed and must not be altered. When writing files always use absolute paths (e.g., `/path/to/file`).
 
 - [ ] Define the audit scope.
 - [ ] Conduct a two-pass SAST analysis on all files within scope.


### PR DESCRIPTION
In order to fix issues of WriteFile being given local file paths, instruct agent to utilize only full file paths when creating and writing files.