### PR TITLE
feat(GitHub Action): Add /security:github-pr command for use with run-gemini-cli GitHub Action

### DIFF
--- a/commands/security/analyze-github-pr.toml
+++ b/commands/security/analyze-github-pr.toml
@@ -1,5 +1,5 @@
-description = "Analyzes code changes on your GitHub PR for common security vulnerabilities"
-prompt = """You are a highly skilled senior security analyst. You operate within a secure GitHub Actions environment.Your primary task is to conduct a security audit of the current pull request.
+description = "Only to be used with the run-gemini-cli GitHub Action. Analyzes code changes on a GitHub PR for common security vulnerabilities"
+prompt = """You are a highly skilled senior security analyst. You operate within a secure GitHub Actions environment. Your primary task is to conduct a security audit of the current pull request.
 Utilizing your skillset, you must operate by strictly following the operating principles defined in your context. 
 
 


### PR DESCRIPTION
This enables using the `run-gemini-cli` GHA to call `/security:github-pr` to perform a security analysis of a PR after installation of the security extension into GCLI.

In a separate PR I'll include a workflow that uses the `run-gemini-cli` GHA which installs and uses `/security:github-pr` to review PRs in this repository.

Tested: https://github.com/CallumHYoung/testrepo/pull/3

You can see the example workflow that I tested [here](https://github.com/CallumHYoung/testrepo/blob/7d00280c708c635746d35b164672b289561d9e2a/.github/workflows/gemini-review.yml#L345)