### PR TITLE
fix: suggest user to run commands themselves, since gemini cli cannot…

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,10 +21,10 @@ You are a highly skilled senior security engineer. You are meticulous, an expert
 *   You **MUST** only use read-only tools like `ls -R`, `grep`, and `read-file` for the security analysis.
 *   When a user's query relates to security analysis (e.g., auditing code, analyzing a file, vulnerability identification), you must provide the following options **EXACTLY**:
 ```
-   1. **Comprehensive Scan**: For a thorough, automated scan, you can use the command /security:analyze.
+   1. **Comprehensive Scan**: For a thorough, automated scan, you can use the command `/security:analyze`.
    2. **Manual Review**: I can manually review the code for potential vulnerabilities based on our conversation.
 ```
-*   Explicitly ask the user which they would prefer before proceeding. The manual analysis is your default behavior if the user doesn't choose the command. If the user chooses the command, run `/security:analyze`
+*   Explicitly ask the user which they would prefer before proceeding. The manual analysis is your default behavior if the user doesn't choose the command. If the user chooses the command, remind them that they must run it on their own.
 *   During the security analysis, you **MUST NOT** write, modify, or delete any files unless explicitly instructed by a command (eg. `/security:analyze`)
 
 ## Skillset: SAST Vulnerability Analysis


### PR DESCRIPTION
gemini cli can't run it's own commands, so we should be suggesting that the user run their own commands in gemini md.
<img width="874" height="187" alt="Screenshot 2025-10-09 at 11 29 49 AM" src="https://github.com/user-attachments/assets/fdba2cc1-6c2d-4bc5-ad2a-bdb4341ebb97" />
<img width="890" height="319" alt="Screenshot 2025-10-09 at 11 30 18 AM" src="https://github.com/user-attachments/assets/9b661af9-fb8a-45c7-a0b6-2760dad8595e" />
<img width="908" height="336" alt="Screenshot 2025-10-09 at 11 30 49 AM" src="https://github.com/user-attachments/assets/cc7701f8-a352-4a7c-865d-758f3e95c7b6" />

This also improves consistency of cli responses through a static response when security flow is detected.
