### PR TITLE
fix(GHA): Gemini-review MCP calls and prompt changes

### DIFF
--- a/commands/security/analyze-github-pr.toml
+++ b/commands/security/analyze-github-pr.toml
@@ -1,5 +1,6 @@
 description = "Only to be used with the run-gemini-cli GitHub Action. Analyzes code changes on a GitHub PR for common security vulnerabilities"
-prompt = """You are a highly skilled senior security analyst. You operate within a secure GitHub Actions environment. Your primary task is to conduct a security audit of the current pull request.
+prompt = """
+You are a highly skilled senior security analyst. You operate within a secure GitHub Actions environment. Your primary task is to conduct a security audit of the current pull request.
 Utilizing your skillset, you must operate by strictly following the operating principles defined in your context. 
 
 
@@ -108,12 +109,12 @@ You will now begin executing the plan. The following are your precise instructio
 1.  **To complete the 'Define the audit scope' task:**
 
     * Input Data
-        - Retrieve the GitHub repository name from the environment variable "${REPOSITORY}".
-        - Retrieve the GitHub pull request number from the environment variable "${PULL_REQUEST_NUMBER}".
-        - Retrieve the additional user instructions and context from the environment variable "${ADDITIONAL_CONTEXT}".
-        - Use `pull_request_read.get` to get the title, body, and metadata about the pull request, as well as information about the files and diff.
-        - Use `pull_request_files.get_files` to get the list of files that were added, removed, and changed in the pull request.
-        - Use `pull_request_diff.get_diff` to get the diff from the pull request. The diff includes code versions with line numbers for the before (LEFT) and after (RIGHT) code snippets for each diff.
+        - **GitHub Repository**: !{echo $REPOSITORY}
+        - **Pull Request Number**: !{echo $PULL_REQUEST_NUMBER}
+        - **Additional User Instructions**: !{echo $ADDITIONAL_CONTEXT}
+        - Use `pull_request_read.get` to get the title, body, and metadata about the pull request.
+        - Use `pull_request_read.get_files` to get the list of files that were added, removed, and changed in the pull request.
+        - Use `pull_request_read.get_diff` to get the diff from the pull request. The diff includes code versions with line numbers for the before (LEFT) and after (RIGHT) code snippets for each diff.
 
     *   Once the command is executed and you have the list of changed files, you will mark this task as complete.
 
@@ -162,4 +163,5 @@ After completing these two initial tasks, continue executing the dynamically gen
         - Keep this section concise and do not repeat details already covered in inline comments.
         </SUMMARY>
 
-Proceed with the Initial Planning Phase now."""
+Proceed with the Initial Planning Phase now.
+"""


### PR DESCRIPTION
Small improvements:
* Directly provide the env variables in the prompt to Gemini CLI rather than asking Gemini to look it up
* Clarity on submission guidelines
* Minor cleaning up of formatting