### PR TITLE
Fix: Fix prompt name for scanning dependencies

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -174,7 +174,7 @@ server.registerTool(
 );
 
 server.registerPrompt(
-  'security:scan_deps',
+  'security:scan-deps',
   {
     title: 'Scan Dependencies',
     description: '[Experimental] Scans dependencies for known vulnerabilities.',


### PR DESCRIPTION
Changes the command name /scan-deps for consistency.